### PR TITLE
fix: Add BoxFit.cover support for video backgrounds to fill entire screen

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,7 +38,7 @@ class MyHomePage extends StatelessWidget {
                   padding: const EdgeInsets.all(24),
                   margin: EdgeInsets.symmetric(horizontal: 20),
                   decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.2),
+                    color: Colors.white.withValues(alpha: 0.2),
                     borderRadius: BorderRadius.circular(16),
                     boxShadow: [
                       BoxShadow(
@@ -52,15 +52,13 @@ class MyHomePage extends StatelessWidget {
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        FlutterLogo(
-                          size: 75,
-                        ),
+                        FlutterLogo(size: 75),
                         const SizedBox(height: 24),
                         TextFormField(
                           decoration: InputDecoration(
                             hintText: 'Email',
                             filled: true,
-                            fillColor: Colors.white.withOpacity(0.5),
+                            fillColor: Colors.white.withValues(alpha: 0.5),
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(8),
                             ),
@@ -72,7 +70,7 @@ class MyHomePage extends StatelessWidget {
                           decoration: InputDecoration(
                             hintText: 'Password',
                             filled: true,
-                            fillColor: Colors.white.withOpacity(0.5),
+                            fillColor: Colors.white.withValues(alpha: 0.5),
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(8),
                             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "1.3.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -107,26 +107,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -155,10 +155,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -224,18 +224,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   video_player:
     dependency: transitive
     description:

--- a/lib/background.dart
+++ b/lib/background.dart
@@ -85,7 +85,14 @@ class _BackgroundState extends State<Background> {
     } else if (_isVideo(widget.path) &&
         _videoController != null &&
         _videoController!.value.isInitialized) {
-      background = VideoPlayer(_videoController!); // Display the video.
+      background = FittedBox(
+        fit: BoxFit.cover, // fills the whole screen
+        child: SizedBox(
+          width: _videoController!.value.size.width,
+          height: _videoController!.value.size.height,
+          child: VideoPlayer(_videoController!),
+        ),
+      ); // Display the video.
     } else {
       background = Container(
           color: Theme.of(context).colorScheme.surface); // Fallback background.


### PR DESCRIPTION
🐛 Problem
Video backgrounds were not covering the full screen area, unlike image backgrounds which use BoxFit.cover. The VideoPlayer widget displays videos at their native dimensions by default, resulting in letterboxing or pillarboxing when the video aspect ratio doesn't match the screen.

✅ Solution
- Wrapped the VideoPlayer widget in a FittedBox with BoxFit.cover to ensure videos scale and fill the entire background area while maintaining their aspect ratio, consistent with how image backgrounds behave.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved background video rendering to ensure optimal screen coverage and aspect ratio handling.
  * Updated color construction syntax and widget declaration styling throughout the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->